### PR TITLE
Version 3.5.6

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -49,7 +49,7 @@ import (
 // App info
 const (
 	APP  = "rep"
-	VER  = "3.5.5"
+	VER  = "3.5.6"
 	DESC = "DNF/YUM repository management utility"
 )
 

--- a/cli/cmd_remove.go
+++ b/cli/cmd_remove.go
@@ -76,7 +76,8 @@ func removePackages(ctx *context, releaseStack, testingStack repo.PackageStack, 
 			printPackageList(ctx.Repo.Testing, testingStack, filter)
 		}
 
-		fmtutil.Separator(false)
+		fmtutil.Separator(true)
+		fmtc.NewLine()
 
 		if !releaseStack.IsEmpty() {
 			fmtc.Printfn(

--- a/cli/cmd_unrelease.go
+++ b/cli/cmd_unrelease.go
@@ -12,6 +12,7 @@ import (
 	"github.com/essentialkaos/ek/v13/fmtutil"
 	"github.com/essentialkaos/ek/v13/options"
 	"github.com/essentialkaos/ek/v13/path"
+	"github.com/essentialkaos/ek/v13/pluralize"
 	"github.com/essentialkaos/ek/v13/spinner"
 	"github.com/essentialkaos/ek/v13/terminal"
 	"github.com/essentialkaos/ek/v13/terminal/input"
@@ -43,11 +44,21 @@ func cmdUnrelease(ctx *context, args options.Arguments) bool {
 
 // unreleasePackages removes packages from release sub-repository
 func unreleasePackages(ctx *context, stack repo.PackageStack, filter string) bool {
+	files := stack.FlattenFiles()
+
 	if !options.GetB(OPT_FORCE) {
 		printPackageList(ctx.Repo.Release, stack, filter)
 
 		fmtutil.Separator(true)
 		fmtc.NewLine()
+
+		fmtc.Printfn(
+			" {s}{*}Release:{!*} -%s %s / -%s{!}", fmtutil.PrettyNum(len(files)),
+			pluralize.Pluralize(len(files), "package", "packages"),
+			fmtutil.PrettySize(files.Size()),
+		)
+
+		fmtutil.Separator(false)
 
 		ok, err := input.ReadAnswer("Do you really want to unrelease these packages?", "n")
 
@@ -55,8 +66,6 @@ func unreleasePackages(ctx *context, stack repo.PackageStack, filter string) boo
 			return false
 		}
 	}
-
-	files := stack.FlattenFiles()
 
 	return unreleasePackagesFiles(ctx, files)
 }

--- a/common/rep.spec
+++ b/common/rep.spec
@@ -15,7 +15,7 @@
 
 Summary:        DNF/YUM repository management utility
 Name:           rep
-Version:        3.5.5
+Version:        3.5.6
 Release:        0%{?dist}
 Group:          Applications/System
 License:        Apache 2.0
@@ -109,6 +109,9 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Tue Aug 05 2025 Anton Novojilov <andy@essentialkaos.com> - 3.5.6-0
+- Fixed minor UI bug with output of 'remove'/'unrelease' commands
+
 * Tue Jun 17 2025 Anton Novojilov <andy@essentialkaos.com> - 3.5.5-0
 - Minor UI improvements
 - Code refactoring


### PR DESCRIPTION
#### Improvements
- Improved output of `unrelease` command

#### Bugfixes
- Fixed minor UI bug with output of `remove` command